### PR TITLE
gcc: remove obsolete options

### DIFF
--- a/gcc/build
+++ b/gcc/build
@@ -27,8 +27,6 @@ esac
     --infodir=/usr/share/info \
     --disable-multilib \
     --disable-symvers \
-    --disable-libmpx \
-    --disable-libmudflap \
     --disable-libsanitizer \
     --disable-werror \
     --disable-fixed-point \


### PR DESCRIPTION
Both options have been obsolete since 4.9 and 5.6 respectively.